### PR TITLE
Explicitly use LoadLibraryW to match wmain.

### DIFF
--- a/openssldir_check.cpp
+++ b/openssldir_check.cpp
@@ -71,7 +71,7 @@ int wmain(int argc, wchar_t **argv)
 		USE_SSLEAY = 1;
 	}
 
-	HINSTANCE hLibModule = LoadLibrary(argv[1]);
+	HINSTANCE hLibModule = LoadLibraryW(argv[1]);
 
 	if (!hLibModule)
 	{


### PR DESCRIPTION
Fixes the build if UNICODE/_UNICODE is/are not defined.